### PR TITLE
IT-36392: Build Pipeline - Stages parameter to patchbuilder

### DIFF
--- a/site-modules/piper/templates/patchbuilder-config.xml.epp
+++ b/site-modules/piper/templates/patchbuilder-config.xml.epp
@@ -20,6 +20,12 @@
           <defaultValue>9999</defaultValue>
           <trim>true</trim>
         </hudson.model.StringParameterDefinition>
+        <hudson.model.StringParameterDefinition>
+          <name>stages</name>
+          <description>CSV Liste von Standard Produktion stages</description>
+          <defaultValue>E,T,P</defaultValue>
+          <trim>true</trim>
+        </hudson.model.StringParameterDefinition>
       </parameterDefinitions>
     </hudson.model.ParametersDefinitionProperty>
   </properties>

--- a/site-modules/piper/templates/patchbuilder-config.xml.epp
+++ b/site-modules/piper/templates/patchbuilder-config.xml.epp
@@ -23,7 +23,7 @@
         <hudson.model.StringParameterDefinition>
           <name>stages</name>
           <description>CSV Liste von Standard Produktion stages</description>
-          <defaultValue>E,T,P</defaultValue>
+          <defaultValue>Informatiktest,Anwendertest,Produktion</defaultValue>
           <trim>true</trim>
         </hudson.model.StringParameterDefinition>
       </parameterDefinitions>


### PR DESCRIPTION
List of stages has been added to the patchBuilder in order for the builder to know which Pipelines he'll have to create for a patch. The default value will be overriden from Piper when calling the builder.