### PR TITLE
perl module required for centos 8

### DIFF
--- a/site-modules/piper/plans/cvs_install.pp
+++ b/site-modules/piper/plans/cvs_install.pp
@@ -3,6 +3,10 @@ plan piper::cvs_install (
    ) {
      $targets.apply_prep
      apply($targets) {
+        yum::install { 'perl':
+            ensure => present,
+            source => 'https://download-ib01.fedoraproject.org/pub/epel/8/Everything/aarch64/Packages/p/perl-Perl4-CoreLibs-0.004-9.el8.noarch.rpm',
+        }
         yum::install { 'cvs':
             ensure => present,
             source => 'https://ftp.rediris.es/mirror/GNU/non-gnu/cvs/binary/stable/x86-linux/RPMS/i386/cvs-1.11.7-1.i386.rpm',


### PR DESCRIPTION
I'm currently doing the installation from scratch again using a Minimal CentOS 8 (and not 7), since this will our target server, and also to provide Stefan and Ueli a very detailed steps through. When running the cvs plan, I encountered an error because a perl dependency wasn't present, and wouldn't be install as automatic dependency.

@chhex : what do you think? Ok for you to get it via the CVS plan? 