### PR TITLE
IT-36769 / Patchserver Setup, Move Target, User , Password from inventory.yaml back to commandline

### DIFF
--- a/inventory.yaml
+++ b/inventory.yaml
@@ -1,19 +1,7 @@
 groups:
    - name: testvms
-     targets:
-        - uri:
-            _plugin: prompt
-            message: Enter the IP or DNS name of the target VM
-          name:  testvm
      config:
         transport: ssh
-        ssh:
-           user:
-             _plugin: prompt
-             message: Enter the SSH user name to access the target VM
-           password:
-             _plugin: prompt
-             message: Enter the SSH user password to access the target VM
         git:
           user: <changeForGitUser>
      vars:

--- a/inventory.yaml
+++ b/inventory.yaml
@@ -15,9 +15,7 @@ groups:
              _plugin: prompt
              message: Enter the SSH user password to access the target VM
         git:
-          user:
-            _plugin: prompt
-            message: Enter the username to access git.apgsga.ch repositories
+          user: <changeForGitUser>
      vars:
        # Local Test Vm specific configuration properties
         admin_user_email : chhenrici@gmail.com

--- a/inventory.yaml
+++ b/inventory.yaml
@@ -2,8 +2,6 @@ groups:
    - name: testvms
      config:
         transport: ssh
-        git:
-          user: <changeForGitUser>
      vars:
        # Local Test Vm specific configuration properties
         admin_user_email : chhenrici@gmail.com

--- a/inventory.yaml
+++ b/inventory.yaml
@@ -1,13 +1,23 @@
 groups:
    - name: testvms
      targets:
-        - uri: centpatch
+        - uri:
+            _plugin: prompt
+            message: Enter the IP or DNS name of the target VM
           name:  testvm
      config:
         transport: ssh
         ssh:
-           user: che
-           password:  che
+           user:
+             _plugin: prompt
+             message: Enter the SSH user name to access the target VM
+           password:
+             _plugin: prompt
+             message: Enter the SSH user password to access the target VM
+        git:
+          user:
+            _plugin: prompt
+            message: Enter the username to access git.apgsga.ch repositories
      vars:
        # Local Test Vm specific configuration properties
         admin_user_email : chhenrici@gmail.com

--- a/patchserver-setup.rb
+++ b/patchserver-setup.rb
@@ -9,7 +9,7 @@ opts = Slop.parse do |o|
   o.array '-i', '--install', 'Bolt installation plans to executed on the target host(s), , separated by <,>, the plan names can also match partially ', delimiter: ','
   o.bool '-s', '--skipClone', 'Skip cloning of  gradle home locally ', default: false
   o.string '-u', '--user', 'SSH Username to access destination VM', required: true
-  o.string '-t', '--target', 'Target host on which bolt plan will be executed', required: true
+  o.string '-t', '--target', 'Target(s) host on which bolt plan will be executed. Multiple targets can be separated with comma', required: true
   o.separator ''
   o.separator 'other options:'
   o.bool '-l', '--list', 'List all Installation Bolt plans '
@@ -90,7 +90,7 @@ end
 
 def run(plan,opts)
   debug = opts[:debug] ? '--debug' : ' '
-  cmd = "bolt plan run #{plan} #{debug} --concurrency 10 --user #{[opts[:user]} --targets #{[opts[target]} --password-prompt"
+  cmd = "bolt plan run #{plan} #{debug} --concurrency 10 --user #{opts[:user]} --targets #{opts[:target]} --password-prompt"
   puts "#{cmd}"
   system(cmd) unless opts[:dry]
   puts "Done: #{plan}"  unless opts[:dry]

--- a/patchserver-setup.rb
+++ b/patchserver-setup.rb
@@ -8,6 +8,8 @@ require 'ostruct'
 opts = Slop.parse do |o|
   o.array '-i', '--install', 'Bolt installation plans to executed on the target host(s), , separated by <,>, the plan names can also match partially ', delimiter: ','
   o.bool '-s', '--skipClone', 'Skip cloning of  gradle home locally ', default: false
+  o.string '-u', '--user', 'SSH Username to access destination VM', required: true
+  o.string '-t', '--target', 'Target host on which bolt plan will be executed', required: true
   o.separator ''
   o.separator 'other options:'
   o.bool '-l', '--list', 'List all Installation Bolt plans '
@@ -88,7 +90,7 @@ end
 
 def run(plan,opts)
   debug = opts[:debug] ? '--debug' : ' '
-  cmd = "bolt plan run #{plan} #{debug} --concurrency 10 -t testvms"
+  cmd = "bolt plan run #{plan} #{debug} --concurrency 10 --user #{[opts[:user]} --targets #{[opts[target]} --password-prompt"
   puts "#{cmd}"
   system(cmd) unless opts[:dry]
   puts "Done: #{plan}"  unless opts[:dry]

--- a/patchserver-setup.rb
+++ b/patchserver-setup.rb
@@ -10,6 +10,7 @@ opts = Slop.parse do |o|
   o.bool '-s', '--skipClone', 'Skip cloning of  gradle home locally ', default: false
   o.string '-u', '--user', 'SSH Username to access destination VM', required: true
   o.string '-t', '--target', 'Target(s) host on which bolt plan will be executed. Multiple targets can be separated with comma', required: true
+  o.string 'gu', '--gitUser', 'Git user to access git.apgsga.ch. Used only during installation process -> provide your own user'
   o.separator ''
   o.separator 'other options:'
   o.bool '-l', '--list', 'List all Installation Bolt plans '
@@ -51,12 +52,11 @@ end
 if !opts[:skipClone]
   bolt_inventory_file = File.join(File.dirname(__FILE__), 'inventory.yaml')
   inventory = YAML.load_file(bolt_inventory_file)
-  user = inventory['groups'].first['config']['git']['user']
   temp_dir = inventory['vars']['temp_gradle']
   if  File.exist?(temp_dir)
     FileUtils.remove_dir(temp_dir, force = true)
   end
-  system("git clone #{user}@git.apgsga.ch:/var/git/repos/apg-gradle-properties.git #{temp_dir}")
+  system("git clone #{opts[:gitUser]}@git.apgsga.ch:/var/git/repos/apg-gradle-properties.git #{temp_dir}")
 end
 if !opts[:install].empty? and opts[:all]
   puts 'Specify either  -a  or -i option, but not both. -a being all plans and -i being a filter on the available plan names '

--- a/patchserver-setup.rb
+++ b/patchserver-setup.rb
@@ -49,7 +49,7 @@ end
 if !opts[:skipClone]
   bolt_inventory_file = File.join(File.dirname(__FILE__), 'inventory.yaml')
   inventory = YAML.load_file(bolt_inventory_file)
-  user = inventory['groups'].first['config']['ssh']['user']
+  user = inventory['groups'].first['config']['git']['user']
   temp_dir = inventory['vars']['temp_gradle']
   if  File.exist?(temp_dir)
     FileUtils.remove_dir(temp_dir, force = true)

--- a/patchserver-setup.rb
+++ b/patchserver-setup.rb
@@ -10,7 +10,7 @@ opts = Slop.parse do |o|
   o.bool '-s', '--skipClone', 'Skip cloning of  gradle home locally ', default: false
   o.string '-u', '--user', 'SSH Username to access destination VM', required: true
   o.string '-t', '--target', 'Target(s) host on which bolt plan will be executed. Multiple targets can be separated with comma', required: true
-  o.string 'gu', '--gitUser', 'Git user to access git.apgsga.ch. Used only during installation process -> provide your own user'
+  o.string '-gu', '--gitUser', 'Git user to access git.apgsga.ch. Used only during installation process -> provide your own user'
   o.separator ''
   o.separator 'other options:'
   o.bool '-l', '--list', 'List all Installation Bolt plans '

--- a/patchserver-setup.rb
+++ b/patchserver-setup.rb
@@ -9,8 +9,7 @@ opts = Slop.parse do |o|
   o.array '-i', '--install', 'Bolt installation plans to executed on the target host(s), , separated by <,>, the plan names can also match partially ', delimiter: ','
   o.bool '-s', '--skipClone', 'Skip cloning of  gradle home locally ', default: false
   o.string '-u', '--user', 'SSH Username to access destination VM', required: true
-  o.string '-t', '--target', 'Target(s) host on which bolt plan will be executed. Multiple targets can be separated with comma', required: true
-  o.string '-gu', '--gitUser', 'Git user to access git.apgsga.ch. Used only during installation process -> provide your own user'
+  o.string '-t', '--target', 'Target group and host (separated by comma) on which bolt plan will be executed. Parameter example (test->group,test.apgsga.ch->target): test,test.apgsga.ch  ', required: true
   o.separator ''
   o.separator 'other options:'
   o.bool '-l', '--list', 'List all Installation Bolt plans '
@@ -56,7 +55,8 @@ if !opts[:skipClone]
   if  File.exist?(temp_dir)
     FileUtils.remove_dir(temp_dir, force = true)
   end
-  system("git clone #{opts[:gitUser]}@git.apgsga.ch:/var/git/repos/apg-gradle-properties.git #{temp_dir}")
+  # TODO JHE : git user, currently hardcoded with jhe -> IT-36770 and IT-36776
+  system("git clone jhe@git.apgsga.ch:/var/git/repos/apg-gradle-properties.git #{temp_dir}")
 end
 if !opts[:install].empty? and opts[:all]
   puts 'Specify either  -a  or -i option, but not both. -a being all plans and -i being a filter on the available plan names '


### PR DESCRIPTION
@chhex , @apgsga-uge

Here a pull request in order to prompt on command line for the following information:

- Target VM on which installations will be performed
- SSH User used to access the target VM
- SSH Password used to access the target VM

Regarding the access to git.apgsga.ch, I added a new property which would have to be changed before running any plan if we clone from git.apgsga.ch. Because the info is eventually needed in the ruby script (cloning repo is optional), I thought it's enough to provide the possibility to set a property, without always prompting for it.