### PR TITLE
IT-36775 / Secrets/ Passwords : Which data should be managed with Puppet Hiera

### DIFF
--- a/inventory.yaml
+++ b/inventory.yaml
@@ -27,8 +27,6 @@ vars:
   # TODO (che, 18.11) Move remaining developer specific properties to specific target group, potential impact on ruby test installation
   maven_profile: artifactory-che
   artifactory_uri: artifactory4t4apgsga.jfrog.io/artifactory
-  artifactory_user: dev
-  artifactory_passwd: SdUi3FY1vwHal33UOM/3DQ==
   yum_repo: multiservice_yumdev
   gradle_home: /var/jenkins/gradle
   maven_home: /var/jenkins/maven

--- a/site-modules/piper/plans/piper_service_properties.pp
+++ b/site-modules/piper/plans/piper_service_properties.pp
@@ -14,7 +14,10 @@ plan piper::piper_service_properties (
           $result = download_file("/etc/opt/apg-patch-service-server/${type}_properties.initial", 'piper', $targets)
           out::message($result)
           $applyResult = apply($targets) {
-            $content = epp($result.first['path'], { 'piper_cvs_user' => "${targetall.config[ssh][user]}", 'jenkins_ssh_user' => "${targetall.config[ssh][user]}" })
+            $content = epp($result.first['path'], { 'piper_cvs_user' => "${targetall.config[ssh][user]}",
+                                                    'jenkins_ssh_user' => "${targetall.config[ssh][user]}",
+                                                    'cm_db_piper_user' => "${lookup('cm::db::piper:user')}",
+                                                    'cm_db_piper_pw' => "${lookup('cm::db::piper:pw')}" })
             file { "/etc/opt/apg-patch-service-server/${type}.properties":
               ensure  => present,
               backup => ".puppet.bk.${timestamp}",

--- a/templates/data/common.yaml
+++ b/templates/data/common.yaml
@@ -1,2 +1,4 @@
 yum::user:name: ops-test
 yum::user:pw: TOBECHANGED
+cm::db::piper:user: cm
+cm::db::piper:pw: TOBECHANGED


### PR DESCRIPTION
Basically, hiera should contain:

yum::user:name: ops-test
yum::user:pw: TOBECHANGED
cm::db::piper:user: cm
cm::db::piper:pw: TOBECHANGED

I couldn't find where artifactory_user and artifactory_pwd are used .... I removed them from inventory.yaml.

@chhex : Could you review it?