### PR TITLE
Various Tickets : IT-36811, IT-36812 and first changes for IT-36775

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ Gemfile.lock
 *.iml
 *.log
 /downloads/
+/hiera-data/common.yaml

--- a/README.md
+++ b/README.md
@@ -25,19 +25,19 @@ Piper see the [Github Repo]() .
 
 ### Set-up Bolt Hiera Config for Passwords
 
-1. `cp templates/hiera.yaml ~/.puppetlabs/bolt`
-2. ` cp -R templates/data ~/.puppetlabs/bolt`
-3. `vim ~/.puppetlabs/bolt/data/common.yaml ` and change TOBECHANGED to
-   the correct value
+The initial hiera configuration file
+[common.yaml.initial](./hiera-data/common.yaml.initial) in the directory
+[hiera-data](./hiera-data) needs to be copied to the same directory to
+common.yaml. This later file is ignored by git.
 
-The location of the root configuration directory can be changed in
-bolt.yaml
+In this file the values with TOBECHANGED needs to be adopted accordingly
+.
 
 ## Running the Setup
 
 ### Installation Parameters
 
-The installation parameters are kept in the **inventory.yaml** file in
+The installation parameters are kept in th **inventory.yaml** file in
 the root directory git repository.
 
 Before the installation this file should be adapted accordingly.

--- a/bolt.yaml
+++ b/bolt.yaml
@@ -1,0 +1,4 @@
+---
+ssh:
+   run-as: root
+   tty: true

--- a/bolt.yaml
+++ b/bolt.yaml
@@ -1,5 +1,0 @@
----
-ssh:
-   run-as: root
-   tty: true
-hiera-config: "~/.puppetlabs/bolt/hiera.yaml"

--- a/hiera-data/common.yaml.initial
+++ b/hiera-data/common.yaml.initial
@@ -1,0 +1,2 @@
+yum::user:name: ops-test  # Artifactory User for yum
+yum::user:pw: TOBECHANGED  # Artifactory User Password

--- a/hiera.yaml
+++ b/hiera.yaml
@@ -4,4 +4,4 @@ hierarchy:
     path: common.yaml
 defaults:
   data_hash: yaml_data
-  datadir: data
+  datadir: hiera-data

--- a/site-modules/piper/templates/jenkins.yaml.epp
+++ b/site-modules/piper/templates/jenkins.yaml.epp
@@ -3,12 +3,6 @@ credentials:
     domainCredentials:
     - credentials:
       - usernamePassword:
-          description: "jadas-e ssh credentials "
-          id: "jadas-e-ssh"
-          password: ""
-          scope: GLOBAL
-          username: "<%= $jenkinsuser %>"
-      - usernamePassword:
           description: "Github Zugang"
           id: "apgsga-jenkins"
           password: ""
@@ -60,7 +54,11 @@ jenkins:
       excludeClientIPFromCrumb: false
   disableRememberMe: false
   disabledAdministrativeMonitors:
+  - "jenkins.security.csrf.CSRFAdministrativeMonitor"
+  - "hudson.model.UpdateCenter$CoreUpdateMonitor"
+  - "jenkins.diagnostics.SecurityIsOffMonitor"
   - "jenkins.diagnostics.RootUrlNotSetMonitor"
+  - "jenkins.security.UpdateSiteWarningsMonitor"
   - "jenkins.security.QueueItemAuthenticatorMonitor"
   - "hudson.diagnosis.ReverseProxySetupMonitor"
   globalNodeProperties:

--- a/site-modules/piper/templates/jenkins.yaml.epp
+++ b/site-modules/piper/templates/jenkins.yaml.epp
@@ -112,20 +112,6 @@ jenkins:
   mode: NORMAL
   myViewsTabBar: "standard"
   nodes:
-  - permanent:
-      labelString: "jenkins_installer_windows jenkins_installer_windows_oldstyle"
-      launcher:
-        jnlp:
-          workDirSettings:
-            disabled: false
-            failIfWorkDirIsMissing: false
-            internalDir: "remoting"
-      mode: EXCLUSIVE
-      name: "apg-jdv-e-001"
-      nodeDescription: "windows test installer"
-      numExecutors: 3
-      remoteFS: "C:\\Software\\jenkinsWork"
-      retentionStrategy: "always"
   numExecutors: 7
   primaryView:
     all:

--- a/templates/data/common.yaml
+++ b/templates/data/common.yaml
@@ -1,2 +1,0 @@
-yum::user:name: ops-test
-yum::user:pw: TOBECHANGED


### PR DESCRIPTION
Commit for for a couple of tickets , see below, for review and feedback. 

The changes need to be tested , but should give the general idea. 

Currently a draft , but any feedback welcomed. 

**IT-36812 : Multiservice_cm: Jenkins "hardening"**

This is achieved by listing  a set "disabledAdministrativeMonitors" in the jenkins casc configuration, see the jenkins.yaml file 

```
  disabledAdministrativeMonitors:
  - "jenkins.security.csrf.CSRFAdministrativeMonitor"
  - "hudson.model.UpdateCenter$CoreUpdateMonitor"
  - "jenkins.diagnostics.SecurityIsOffMonitor"
  - "jenkins.diagnostics.RootUrlNotSetMonitor"
  - "jenkins.security.UpdateSiteWarningsMonitor"
  - "jenkins.security.QueueItemAuthenticatorMonitor"
  - "hudson.diagnosis.ReverseProxySetupMonitor"
```

**IT-36775 : Secrets/ Passwords : Which data should be managed with Puppet Hiera**

This is more about the how at the moment then the which. 

Basically the hiera configuration is now in within the repo directory, but the file which contains the secrets (common.yaml) is ignored by git. This will make it easier to add for example target group specific secrets, the ssh key files etc. 
So it is a intermediate step, which should be backward compatible. 

**IT-36811 : Add Revision Init for Test Setup**

Here i added / modified the following options, see patchserver-tests-setup.rb and the options being with -c : 

```
 ./patchserver-tests-setup.rb [options]
    .....
    -cc, --cleanRepoCaches   Cleans Maven and Gradle Cache, default: false
    -cm, --cleanMavenCache   Cleans Maven, default: false
    -cg, --cleanGradleCache  Cleans Maven, default: false
    -ct, --cleanArtifactory  Cleans the specific repos in Artifactory according to Profile, default: false
    -cr, --cleanRevisions    Remove all revision files, default: false
    -ca, --cleanAll          Execute all clean options, default: false
   ....

```
So it is now possible to initial fine granular (-cc, -cm, -cg, -ct, -cr)  and also all (-ca) 


