### PR TITLE
Bad credentials when cleaning Artifactory repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,23 +196,25 @@ different options for
 - Deleting the Maven Local and the gradle Cache on the target host
 - Emptying the Artifactory test repos according the Maven Profile
   settings
-- Creating the Testjobs according to  [testappsconfig.yaml](./testappsconfig.yaml),
-  all or selectively by Testapp
-- Deleting Testjobs according to [testappsconfig.yaml](./testappsconfig.yaml), all or
-  selectively by Testapp
+- Creating the Testjobs according to
+  [inventory-local.yaml](./inventory-local.yaml), all or selectively by
+  Testapp
+- Deleting Testjobs according to
+  [inventory-local.yaml](./inventory-local.yaml), all or selectively by
+  Testapp
 - Running all Testjobs according to
-  [testappsconfig.yaml](./testappsconfig.yaml),, all or selectively
+  [inventory-local.yaml](./inventory-local.yaml),, all or selectively
 
 The configuration is pulled from the
 [Bolt inventory file](./inventory.yaml) of the Puppet Setup of the
 Target and the local
-[Configuration of the Testapp Metadata](./testappsconfig.yaml)
+[Configuration of the Testapp Metadata](./inventory-local.yaml)
 
 The Artifactory admin user needs to be configured in the above file.
 
 Preconditions:
 - Jenkins running in the target VM running on the IP Address, according
-  to [testappsconfig.yaml](./testappsconfig.yaml)
+  to [inventory-local.yamll](./inventory-local.yaml)
 - The
   [Bolt Inventory file](https://github.com/apgsga-it/patchserver-setup/blob/master/inventory.yaml)
   needs to reflect the running Target Server and accessible  on the local
@@ -246,21 +248,13 @@ with the -h or --help option, you see the following
 ### Configuration
 
 The Configuration is taken from the file
-[testappsconfig.yaml](./testappsconfig.yaml) and from the Bolt Puppet
+[inventory-local.yaml](./inventory-local.yaml) and from the Bolt Puppet
 [Inventory file](https://github.com/apgsga-it/patchserver-setup/blob/master/inventory.yaml)
 of the
 [Patch Server Setup](https://github.com/apgsga-it/patchserver-setup).
 
 
 Both must reflect the current state of the running target.
-
-The Artifactory user is configured also in the file
-[testappsconfig.yaml](./testappsconfig.yaml) , see
-
-`artifactory:
-  admin: che`
-
-for example
 
 ### Usage Scenarios
 
@@ -273,13 +267,13 @@ Empty the test specific Artifactory  Repositories
 `./init-jenkins-tests.rb --cleanArtifactory`
 
 Create all Tests Jobs according to
-[testappsconfig.yaml](./testappsconfig.yaml)
+[inventory-local.yaml](./inventory-local.yaml)
 
 
 `./init-jenkins-tests.rb --createAllJobs`
 
 Create Tests Jobs for a specific Testapp according to
-[testappsconfig.yaml](./testappsconfig.yaml)
+[inventory-local.yaml](./inventory-local.yaml)
 
 `./init-jenkins-tests.rb --createAppJobs testapp`
 

--- a/inventory-local.yaml
+++ b/inventory-local.yaml
@@ -19,8 +19,6 @@ vars:
   yum_repo: multiservice_yumdev
 
 # For Testing , see ./patchserver-tests-setup.rb
-artifactory:
-  admin: che
 testapps:
   - name: testapp
     rootdir: apg-gradle-plugins-testsmodules/testapp/

--- a/ruby-testlibs/jenkins/test_apps.rb
+++ b/ruby-testlibs/jenkins/test_apps.rb
@@ -19,10 +19,10 @@ module Jenkins
     attr_reader :user, :pw, :target, :test_apps, :gradle_home, :maven_home, :artifactory_admin, :artifactory_uri, :maven_profile
     include Visitable
 
-    def initialize(usr, secrets, inventory_file, local_inventory_file)
+    def initialize(user, secrets, inventory_file, local_inventory_file)
       inventory = YAML.load_file(inventory_file)
       inventory_local = YAML.load_file(local_inventory_file)
-      @user = usr
+      @user = user
       @secrets = secrets
       @target = inventory_local['targets'].first['uri']
       @gradle_home = inventory['vars']['gradle_home']
@@ -30,7 +30,6 @@ module Jenkins
       @artifactory_uri = inventory['vars']['artifactory_uri']
       @maven_profile = inventory['vars']['maven_profile']
       @test_apps = []
-      @artifactory_admin = inventory_local['artifactory']['admin']
       apps_config_context = inventory_local['testapps']
       apps_config_context.each do |app_config_context|
         modules_names = app_config_context['modules'].split(' ')

--- a/site-modules/piper/templates/jenkins.yaml.epp
+++ b/site-modules/piper/templates/jenkins.yaml.epp
@@ -75,7 +75,7 @@ jenkins:
       - key: "GITHUB_JENKINS_VERSION"
         value: "<%= $github_jenkins_version %>"
       - key: "GRADLE_OPTS"
-        value: "-Dgradle.user.home=<%= $gradle_home %>/home -Dorg.gradle.daemon=false"
+        value: "-Dgradle.user.home=<%= $gradle_home %>/home"
       - key: "GRADLE_USER_HOME_PATH"
         value: "<%= $gradle_home %>/home"
       - key: "REVISIONS_FILES_PATH"


### PR DESCRIPTION
Following changes: 

- Introduced a optional new --artifactoryAdmin parameter 
- If not present defaults to --user user 
- The password will be prompted in any case, since the user(s) may be the same, but the Password can be different
- Different Encrypted password storages 

