### PR TITLE
CM-327 / different docker profile

### DIFF
--- a/inventory-local.yaml
+++ b/inventory-local.yaml
@@ -9,7 +9,7 @@ config:
 vars:
   piper_bind_address:  # empty for local testing
   piper_cvs_remote_host: cvs-t.apgsga.ch
-  piper_spring_profiles: live,remotecvs, patchOMock
+  piper_spring_profiles: live,remotecvs, patchOMock,mockDocker
   cm_db_host: chti212.apgsga.ch
   cm_db_instance: chti212
   yum_repo: multiservice_yumdev

--- a/inventory-prod.yaml
+++ b/inventory-prod.yaml
@@ -9,7 +9,7 @@ vars:
   admin_user_email : it.architektur@apgsga.ch
   piper_bind_address:  localhost
   piper_cvs_remote_host: cvs.apgsga.ch
-  piper_spring_profiles: live,remotecvs,patchOMat
+  piper_spring_profiles: live,remotecvs,patchOMat,liveDocker
   artifactory_repo: repo
   cm_db_host: chti212.apgsga.ch
   cm_db_instance: chti212

--- a/inventory-test.yaml
+++ b/inventory-test.yaml
@@ -9,7 +9,7 @@ vars:
  # Local Test Vm specific configuration properties
   piper_bind_address:  localhost
   piper_cvs_remote_host: cvs-t.apgsga.ch
-  piper_spring_profiles: live,remotecvs, patchOMat
+  piper_spring_profiles: live,remotecvs, patchOMat, mockDocker
   cm_db_host: chti212.apgsga.ch
   cm_db_instance: chti212
   yum_repo: multiservice_yumdev # TODO (che, 23.2 ) : needs to be verified


### PR DESCRIPTION
Hi @chhex ,
If OK for you, here a pull request in order to add different Spring profile for docker-services integration.
Basically, to configure the following changes made on Piper: https://github.com/apgsga-it/piper/commit/5c17167a5f2a09c31c53f5500662b578f47b437a
I'll wait before merging to be sure I'm not disturbing anything you maybe have in progress on patchserver-setup side.
Cheers!